### PR TITLE
Filtering sorting pagination tasks

### DIFF
--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -11,6 +11,7 @@ const {
   updateUser,
   removeUser,
 } = require("./user");
+
 const {
   createTask,
   readTasks,
@@ -20,6 +21,7 @@ const {
   removeAllTasks,
 } = require("./task");
 
+// User Routers
 router.post("/users/signup", signup);
 router.post("/users/login", login);
 router.get("/users/me", auth, userProfile);
@@ -28,6 +30,7 @@ router.post("/users/logoutAll", auth, logoutAll);
 router.patch("/users/me", auth, updateUser);
 router.delete("/users/me", auth, removeUser);
 
+// Task routers
 router.post("/tasks", auth, createTask);
 router.get("/tasks", auth, readTasks);
 router.get("/tasks/:id", auth, getSingleTask);

--- a/src/routers/task.js
+++ b/src/routers/task.js
@@ -16,9 +16,15 @@ const createTask = async (req, res) => {
 
 const readTasks = async (req, res) => {
   const author = req.user._id;
+  const query = req.query.completed;
+  const options = { author };
+
+  // Add completed option to the obj options passed into find Task.
+  if (query === "false") options.completed = false;
+  if (query === "true") options.completed = true;
 
   try {
-    const tasks = await Task.find({ author });
+    const tasks = await Task.find(options);
     res.status(201).send(tasks);
   } catch (err) {
     res.status(500).send();

--- a/src/routers/task.js
+++ b/src/routers/task.js
@@ -15,11 +15,13 @@ const createTask = async (req, res) => {
 };
 
 const readTasks = async (req, res) => {
+  const { completed, limit, skip, sortBy } = req.query;
+
   const author = req.user._id;
   const options = { author };
-  const completedQuery = req.query.completed;
-  const limitQuery = parseInt(req.query.limit);
-  const skipQuery = parseInt(req.query.skip);
+  const completedQuery = completed;
+  const limitQuery = parseInt(limit);
+  const skipQuery = parseInt(skip);
   const sortQuery = {};
 
   // in case completed query is provideded, populate the options obj wich is  passed into find Task.
@@ -28,8 +30,8 @@ const readTasks = async (req, res) => {
   //
 
   // In case sortQuery is provided, populate the object passed into sort method.
-  if (req.query.sortBy) {
-    const parts = req.query.sortBy.split(":");
+  if (sortBy) {
+    const parts = sortBy.split(":");
     sortQuery[parts[0]] = parts[1];
   }
   //

--- a/src/routers/task.js
+++ b/src/routers/task.js
@@ -19,13 +19,14 @@ const readTasks = async (req, res) => {
   const query = req.query.completed;
   const options = { author };
   const limitQuery = parseInt(req.query.limit);
+  const skipQuery = parseInt(req.query.skip);
 
   // Add completed option to the obj options passed into find Task.
   if (query === "false") options.completed = false;
   if (query === "true") options.completed = true;
 
   try {
-    const tasks = await Task.find(options).limit(limitQuery);
+    const tasks = await Task.find(options).limit(limitQuery).skip(skipQuery);
     res.status(201).send(tasks);
   } catch (err) {
     res.status(500).send();

--- a/src/routers/task.js
+++ b/src/routers/task.js
@@ -18,13 +18,14 @@ const readTasks = async (req, res) => {
   const author = req.user._id;
   const query = req.query.completed;
   const options = { author };
+  const limitQuery = parseInt(req.query.limit);
 
   // Add completed option to the obj options passed into find Task.
   if (query === "false") options.completed = false;
   if (query === "true") options.completed = true;
 
   try {
-    const tasks = await Task.find(options);
+    const tasks = await Task.find(options).limit(limitQuery);
     res.status(201).send(tasks);
   } catch (err) {
     res.status(500).send();

--- a/src/routers/task.js
+++ b/src/routers/task.js
@@ -16,17 +16,29 @@ const createTask = async (req, res) => {
 
 const readTasks = async (req, res) => {
   const author = req.user._id;
-  const query = req.query.completed;
   const options = { author };
+  const completedQuery = req.query.completed;
   const limitQuery = parseInt(req.query.limit);
   const skipQuery = parseInt(req.query.skip);
+  const sortQuery = {};
 
-  // Add completed option to the obj options passed into find Task.
-  if (query === "false") options.completed = false;
-  if (query === "true") options.completed = true;
+  // in case completed query is provideded, populate the options obj wich is  passed into find Task.
+  if (completedQuery === "false") options.completed = false;
+  if (completedQuery === "true") options.completed = true;
+  //
+
+  // In case sortQuery is provided, populate the object passed into sort method.
+  if (req.query.sortBy) {
+    const parts = req.query.sortBy.split(":");
+    sortQuery[parts[0]] = parts[1];
+  }
+  //
 
   try {
-    const tasks = await Task.find(options).limit(limitQuery).skip(skipQuery);
+    const tasks = await Task.find(options)
+      .limit(limitQuery)
+      .skip(skipQuery)
+      .sort(sortQuery);
     res.status(201).send(tasks);
   } catch (err) {
     res.status(500).send();


### PR DESCRIPTION
## Description

- Enable the user to query tasks by completed/incompleted.

- Enable user to set a limit query. This is a huge advantage for performance. The user doesn't need to fetch all tasks at the same time. The limit query will come in handy for **pagination** or invisible **scrolling**.

- Enable the user to skip some results by using **skip** query. For instance, if the user wants only the two first results per page.

- Enable the user to sort the tasks dynamically. For instance, ascending/descend based createdAt or UpdatedAt or a different property.

_The app is deployed to Heroku and can be tested on Postman._
#### Test it in Postman by clicking on the button below :point_down: :point_down: :point_down: 
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/cbb95ee6f7444f44e9da#?env%5BTask%20Manager%20APi%20(production)%5D=W3sia2V5IjoidXJsIiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlfSx7ImtleSI6ImF1dGhUb2tlbiIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX1d)

_Check it under **"Read Tasks"** request_

